### PR TITLE
Use ldap attribute member rather than uniqueMember to lookup groups.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,6 +1,5 @@
 class Ability
   include Hydra::Ability
-  
   include CurationConcerns::Ability
   self.ability_logic += [:everyone_can_create_curation_concerns]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,12 +7,12 @@ class User < ActiveRecord::Base
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User
 
-  # Fetch groups from LDAP
-  include WithLdapGroups
-
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :ldap_authenticatable, :rememberable, :trackable
+
+  # Fetch groups from LDAP. Must come after `devise` call.
+  include WithLdapGroups
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for


### PR DESCRIPTION
Fixes #129
